### PR TITLE
Added Situation-related skeleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
       <version>2.6.1</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/text_engine/effects/Effect.java
+++ b/src/text_engine/effects/Effect.java
@@ -8,7 +8,7 @@ import text_engine.items.GameEntity;
 /**
  * Represents something that changes the state of the game.
  */
-public abstract class Effect<T extends GameEntity> extends GameEntity implements Consumer<GameCharacter> {
+public abstract class Effect<T extends GameEntity> extends GameEntity implements Consumer<T> {
 
     protected final String report;
     protected final Consumer<T> consumer;

--- a/src/text_engine/effects/GameCharacterEffect.java
+++ b/src/text_engine/effects/GameCharacterEffect.java
@@ -19,13 +19,6 @@ public class GameCharacterEffect extends Effect<GameCharacter> {
         this.consumer.accept(gameCharacter);
     }
 
-    public static final GameCharacterEffect NULL =
-            new GameCharacterEffect(
-                    "No effect.",
-                    "",
-                    "",
-                    (player) -> {});
-
     public static final GameCharacterEffect CLEAR_INVENTORY =
             new GameCharacterEffect(
                     "Clear Inventory",

--- a/src/text_engine/effects/GameEntityEffect.java
+++ b/src/text_engine/effects/GameEntityEffect.java
@@ -1,0 +1,22 @@
+package text_engine.effects;
+
+import text_engine.items.GameEntity;
+
+import java.util.function.Consumer;
+
+public class GameEntityEffect extends Effect<GameEntity> {
+    public GameEntityEffect(String name, String description, String report, Consumer<GameEntity> consumer) {
+        super(name, description, report, consumer);
+    }
+
+    @Override
+    public void accept(GameEntity gameEntity) {
+        consumer.accept(gameEntity);
+    }
+
+    public static final GameEntityEffect NULL = new GameEntityEffect(
+            "No effect.",
+            "",
+            "",
+            (gameEntity) -> { });
+}

--- a/src/text_engine/situations/SituationLeaf.java
+++ b/src/text_engine/situations/SituationLeaf.java
@@ -1,0 +1,40 @@
+package text_engine.situations;
+
+import text_engine.effects.Effect;
+import text_engine.items.GameEntity;
+
+public class SituationLeaf {
+    private final SituationNode parent;
+    private final Effect<GameEntity> effect;
+    private final NextSituation next;
+
+    /**
+     * The next stop on the Situation train for {@link this} node.
+     */
+    public enum NextSituation {
+        PARENT, ROOT, EXIT
+    }
+
+    /**
+     * Create a new {@link SituationLeaf}.
+     *
+     * @param parent the parent of {@link this}
+     * @param effect the effect that {@link this} should have after completion
+     * @param next the next place to move to
+     */
+    public SituationLeaf(SituationNode parent, Effect<GameEntity> effect, NextSituation next) {
+        this.parent = parent;
+        this.effect = effect;
+        this.next = next;
+    }
+
+    protected SituationNode root() {
+        return parent.root();
+    }
+
+    void select(GameEntity gameEntity) {
+        effect.accept(gameEntity);
+        // will replace this with `interact` with relevant exceptions & console
+        // interaction
+    }
+}

--- a/src/text_engine/situations/SituationNode.java
+++ b/src/text_engine/situations/SituationNode.java
@@ -1,0 +1,55 @@
+package text_engine.situations;
+
+import text_engine.effects.Effect;
+import text_engine.items.GameEntity;
+
+import java.util.List;
+
+public class SituationNode extends SituationLeaf {
+    List<SituationNode> situationNodes;
+    List<SituationLeaf> situationLeaves;
+
+    public SituationNode(SituationNode parent, Effect<GameEntity> effect, NextSituation next) {
+        super(parent, effect, next);
+    }
+
+    public SituationNode addChildLeafToExit(Effect<GameEntity> effect) {
+        addChildLeaf(effect, NextSituation.EXIT);
+        return this;
+    }
+
+    public SituationNode addChildLeafToParent(Effect<GameEntity> effect) {
+        addChildLeaf(effect, NextSituation.PARENT);
+        return this;
+    }
+
+    public SituationNode addChildLeafToRoot(Effect<GameEntity> effect) {
+        addChildLeaf(effect, NextSituation.ROOT);
+        return this;
+    }
+
+    public SituationNode addChildLeaf(Effect<GameEntity> effect, NextSituation next) {
+        situationLeaves.add(new SituationLeaf(this, effect, next));
+        return this;
+    }
+
+    public SituationNode addChildNodeToExit(Effect<GameEntity> effect) {
+        addChildNode(effect, NextSituation.EXIT);
+        return this;
+    }
+
+    public SituationNode addChildNodeToParent(Effect<GameEntity> effect) {
+        addChildNode(effect, NextSituation.PARENT);
+        return this;
+    }
+
+    public SituationNode addChildNodeToRoot(Effect<GameEntity> effect) {
+        addChildNode(effect, NextSituation.ROOT);
+        return this;
+    }
+
+    public SituationNode addChildNode(Effect<GameEntity> effect, NextSituation next) {
+        situationNodes.add(new SituationNode(this, effect, next));
+        return this;
+    }
+}

--- a/src/text_engine/situations/SituationRoot.java
+++ b/src/text_engine/situations/SituationRoot.java
@@ -1,0 +1,21 @@
+package text_engine.situations;
+
+import text_engine.effects.Effect;
+import text_engine.effects.GameEntityEffect;
+import text_engine.items.GameEntity;
+
+public class SituationRoot extends SituationNode {
+
+    public SituationRoot(Effect<GameEntity> effect) {
+        super(null, effect, NextSituation.EXIT);
+    }
+
+    public SituationRoot() {
+        this(GameEntityEffect.NULL);
+    }
+
+    @Override
+    public SituationNode root() {
+        return this;
+    }
+}


### PR DESCRIPTION
Still rather useless until we add some kind of execution. Also, adding multiple `SituationNode`s with children of their own is problematic with the current builder format. I'll think of some way to improve that later, and am open to suggestions. Likely just an `addMany()` with the ability to easily instantiate `SituationNode`s and `SituationLeaf`s.

Only part of the work for #20.