### PR TITLE
Easily create Combinations

### DIFF
--- a/src/text_engine/interaction/Interactive.java
+++ b/src/text_engine/interaction/Interactive.java
@@ -23,9 +23,9 @@ public abstract class Interactive {
      *     catch (RelevantExceptionToThisClass) {
      *         continue;
      *     }
-     * } while (height = 0);
+     * } while (height == 0);
      *
-     * return height;
+     * return height - 1;
      * </pre>
      *
      * The minimum {@code 1} return value means that, by default, we will always be doing an action

--- a/src/text_engine/items/Item.java
+++ b/src/text_engine/items/Item.java
@@ -12,6 +12,7 @@ import java.util.Stack;
 
 import text_engine.characters.GameCharacter;
 import text_engine.effects.Effect;
+import text_engine.items.combinations.Combination;
 import text_engine.items.combinations.Combinations;
 
 /**
@@ -60,6 +61,38 @@ public class Item extends GameEntity implements Serializable {
     @Override
     public boolean isConsumable() {
         return !effects.isEmpty();
+    }
+
+    /**
+     * Adds the given list of {@link Item}s as a new {@link Combination} to the {@link Combinations}
+     * of both {@link this} and all of the other given {@link Item}s.
+     *
+     * Returns {@link this} so it can be used in a pseudo-builder style.
+     *
+     * @param items {@link Item}s to be added to the new {@link Combination}
+     * @param result result of the {@link Combination}
+     * @return {@link this}
+     */
+    public Item addCombination(Item result, Item... items) {
+        Combination combination = new Combination(items);
+
+        for (Item otherItem : items) {
+            otherItem.addCombination(combination, result);
+        }
+
+        return addCombination(combination, result);
+    }
+
+    /**
+     * Adds the given combination to {@link this} {@link Item}'s {@link Combinations}.
+     *
+     * @param combination {@link Combination} to add
+     * @param result result of the {@link Combination}
+     * @return {@link this}
+     */
+    private Item addCombination(Combination combination, Item result) {
+        combinations.put(combination, result);
+        return this;
     }
 
     @Override


### PR DESCRIPTION
Closes #33.

Makes it easy to add a `Combination` on an `Item` and have that `Combination` propagate to all the other involved `Item`s.