### PR TITLE
Pull out base class functionality

### DIFF
--- a/src/text_engine/boundaries/Room.java
+++ b/src/text_engine/boundaries/Room.java
@@ -12,13 +12,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-import text_engine.items.GameEntity;
+import text_engine.items.BaseGameEntity;
 import text_engine.items.Item;
 
 /**
  * Represents a room.
  */
-public class Room extends GameEntity implements Serializable {
+public class Room extends BaseGameEntity implements Serializable {
 
     public static final int CONTENT_LIMIT = 10;
   /*

--- a/src/text_engine/characters/GameCharacter.java
+++ b/src/text_engine/characters/GameCharacter.java
@@ -7,14 +7,14 @@ import java.util.Objects;
 
 import text_engine.boundaries.Door;
 import text_engine.boundaries.Room;
-import text_engine.items.GameEntity;
+import text_engine.items.BaseGameEntity;
 import text_engine.items.Item;
 import text_engine.items.Key;
 
 /**
  * Represents an in-game character, including both the player character and NPCs.
  */
-public class GameCharacter extends GameEntity implements Cloneable {
+public class GameCharacter extends BaseGameEntity implements Cloneable {
 
     private final List<Item> inventory;
     private Room location;

--- a/src/text_engine/effects/BaseEffector.java
+++ b/src/text_engine/effects/BaseEffector.java
@@ -1,0 +1,68 @@
+package text_engine.effects;
+
+import com.sun.istack.internal.NotNull;
+
+import sun.plugin.dom.exception.InvalidStateException;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Stack;
+import java.util.Vector;
+
+import text_engine.characters.GameCharacter;
+import text_engine.items.BaseGameEntity;
+import text_engine.items.GameEntity;
+
+/**
+ * All {@link BaseGameEntity}'s which apply some kind of {@link Effect} should implement {@link
+ * Effector} and delegate to a {@link BaseEffector}.
+ */
+public class BaseEffector extends BaseGameEntity implements Effector {
+
+    private final Stack<Effect<? extends GameEntity>> effects;
+
+    public BaseEffector(Stack<Effect<? extends GameEntity>> effects) {
+        this.effects = effects;
+    }
+
+    public BaseEffector(List<Effect<? extends GameEntity>> effects) {
+        this.effects = new Stack<>();
+        this.effects.addAll(effects);
+    }
+
+    /**
+     * Apply {@link this} object's {@link Effect}s to the given {@link GameCharacter}.
+     *
+     * @param gameCharacter the {@link GameCharacter} to apply {@link Effect}s to.
+     */
+    @Override
+    public void apply(@NotNull GameCharacter gameCharacter) {
+        Objects.requireNonNull(gameCharacter);
+        if (!(hasEffects())) {
+            throw new InvalidStateException(String.format("%s has no effects.", this.getName()));
+        }
+
+        while (!effects.isEmpty()) {
+            effects.pop().accept(gameCharacter);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasEffects() {
+        return !effects.isEmpty();
+    }
+
+    /**
+     * Return a {@link Vector} of effects contained by this {@link Effector}.
+     */
+    @Override
+    public Vector<Effect<? extends GameEntity>> getEffects() {
+        @SuppressWarnings("unchecked")
+        Vector<Effect<? extends GameEntity>>
+                result = (Vector<Effect<? extends GameEntity>>) effects.clone();
+        return result;
+    }
+}

--- a/src/text_engine/effects/Effect.java
+++ b/src/text_engine/effects/Effect.java
@@ -3,12 +3,13 @@ package text_engine.effects;
 import java.util.function.Consumer;
 
 import text_engine.characters.GameCharacter;
+import text_engine.items.BaseGameEntity;
 import text_engine.items.GameEntity;
 
 /**
  * Represents something that changes the state of the game.
  */
-public abstract class Effect<T extends GameEntity> extends GameEntity implements Consumer<GameCharacter> {
+public abstract class Effect<T extends GameEntity> extends BaseGameEntity implements Consumer<GameCharacter> {
 
     protected final String report;
     protected final Consumer<T> consumer;

--- a/src/text_engine/effects/Effector.java
+++ b/src/text_engine/effects/Effector.java
@@ -1,0 +1,33 @@
+package text_engine.effects;
+
+import com.sun.istack.internal.NotNull;
+
+import java.util.Collection;
+import java.util.Vector;
+
+import text_engine.characters.GameCharacter;
+import text_engine.items.GameEntity;
+
+public interface Effector {
+
+    /**
+     * Apply {@link this} {@link Effector}'s {@link Effect}s to the given {@link GameCharacter}.
+     *
+     * @param gameCharacter the {@link GameCharacter} to apply {@link Effect}s to.
+     * @throws IllegalStateException no effects to apply.
+     */
+    void apply(@NotNull GameCharacter gameCharacter) throws IllegalStateException;
+
+    /**
+     * Also implies whether {@link #apply(GameCharacter)} will perform any actions or throw an
+     * {@link IllegalStateException}.
+     *
+     * @return whether {@link this} has any effects
+     */
+    boolean hasEffects();
+
+    /**
+     * Return the {@link Collection} of effects contained by this {@link Effector}.
+     */
+    Vector<Effect<? extends GameEntity>> getEffects();
+}

--- a/src/text_engine/items/BaseGameEntity.java
+++ b/src/text_engine/items/BaseGameEntity.java
@@ -1,0 +1,102 @@
+package text_engine.items;
+
+import com.sun.istack.internal.NotNull;
+
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.util.Objects;
+
+import text_engine.characters.GameCharacter;
+
+/**
+ * Represents a generic in-game object, including characters, interactive items, etc.
+ */
+public class BaseGameEntity implements GameEntity {
+
+    private String name;
+    private String description;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(@NotNull String name) {
+        this.name = Objects.requireNonNull(name);
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public void setDescription(@NotNull String description) {
+        this.description = Objects.requireNonNull(description);
+    }
+
+    /**
+     * Constructs a new item {@link BaseGameEntity}.
+     *
+     * @param name        The name of the object
+     * @param description The description of the object
+     */
+    public BaseGameEntity(@NotNull String name, @NotNull String description) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(description);
+
+        setName(name);
+        setDescription(description);
+    }
+
+    /**
+     * Initialise a new {@link BaseGameEntity} with no name or description.
+     */
+    public BaseGameEntity() {
+        this.name = "";
+        this.description = "";
+    }
+
+    @Override
+    public boolean isCompatible(Item... otherItems) {
+        return false;
+    }
+
+    @Override
+    public boolean isCombinable() {
+        return false;
+    }
+
+    @Override
+    public boolean isConsumable() {
+        return false;
+    }
+
+    @Override
+    public void consume(GameCharacter gameCharacter) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public String toString() {
+        return this.name.concat(": ").concat(this.description);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BaseGameEntity gameEntity = (BaseGameEntity) o;
+        return getName().equals(gameEntity.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/src/text_engine/items/GameEntity.java
+++ b/src/text_engine/items/GameEntity.java
@@ -2,70 +2,31 @@ package text_engine.items;
 
 import com.sun.istack.internal.NotNull;
 
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 import java.io.Serializable;
-import java.util.Objects;
 
 import text_engine.characters.GameCharacter;
 
-/**
- * Represents a generic in-game object, including characters, interactive items, etc.
- */
-public class GameEntity implements Serializable, Cloneable {
-
-    private String name;
-    private String description;
+public interface GameEntity extends Serializable, Cloneable {
 
     /**
      * @return name of this {@link GameEntity}
      */
-    public String getName() {
-        return name;
-    }
+    String getName();
 
     /**
      * Set the name of this {@link GameEntity}
      */
-    public void setName(@NotNull String name) {
-        this.name = Objects.requireNonNull(name);
-    }
+    void setName(@NotNull String name);
 
     /**
      * @return description of this {@link GameEntity}
      */
-    public String getDescription() {
-        return description;
-    }
+    String getDescription();
 
     /**
      * Set the description of this {@link GameEntity}
      */
-    public void setDescription(@NotNull String description) {
-        this.description = Objects.requireNonNull(description);
-    }
-
-    /**
-     * Constructs a new item {@link GameEntity}.
-     *
-     * @param name        The name of the object
-     * @param description The description of the object
-     */
-    public GameEntity(@NotNull String name, @NotNull String description) {
-        Objects.requireNonNull(name);
-        Objects.requireNonNull(description);
-
-        setName(name);
-        setDescription(description);
-    }
-
-    /**
-     * Initialise a new {@link GameEntity} with no name or description.
-     */
-    public GameEntity() {
-        this.name = "";
-        this.description = "";
-    }
+    void setDescription(@NotNull String description);
 
     /**
      * Standard {@link GameEntity}s cannot be combined with anything.
@@ -73,51 +34,21 @@ public class GameEntity implements Serializable, Cloneable {
      * @param otherItems The other items to combine with.
      * @return {@code false}
      */
-    public boolean isCompatible(Item... otherItems) {
-        return false;
-    }
+    boolean isCompatible(Item... otherItems);
 
     /**
      * Standard {@link GameEntity}s cannot be combined with anything.
      *
      * @return {@code false}
      */
-    public boolean isCombinable() {
-        return false;
-    }
+    boolean isCombinable();
 
     /**
      * Standard {@link GameEntity}s cannot be consumed.
      *
      * @return {@code false}
      */
-    public boolean isConsumable() {
-        return false;
-    }
+    boolean isConsumable();
 
-    public void consume(GameCharacter gameCharacter) {
-        throw new NotImplementedException();
-    }
-
-    @Override
-    public String toString() {
-        return this.name.concat(": ").concat(this.description);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        GameEntity gameEntity = (GameEntity) o;
-        return name.equals(gameEntity.name);
-    }
-
-    @Override
-    public int hashCode() {
-        return name.hashCode();
-    }
+    void consume(GameCharacter gameCharacter);
 }


### PR DESCRIPTION
Closes #21.

- Refactored `Effect`s to be used through `BaseEffector` class
    + `Item` (and anything else that will cause effects for one reason
      or another) will now delegate to a `BaseEffector` where relevant.
- Pulled out all common methods of `GameEntity` into an interface and
  renamed the class to `BaseGameEntity`.