### PR TITLE
JavaDoc Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 settings.xml
 
 # Java output directory
+doc/
 out/
 target/
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.0.1</version>
+      </plugin>
+
+      <plugin>
         <groupId>com.github.github</groupId>
         <artifactId>site-maven-plugin</artifactId>
         <version>0.12</version>

--- a/src/bobbin/effects/BaseEffector.java
+++ b/src/bobbin/effects/BaseEffector.java
@@ -26,7 +26,7 @@ public class BaseEffector extends BaseGameEntity implements Effector {
     }
 
     /**
-     * Apply {@link this} object's {@link BaseEffect}s to the given {@link GameCharacter}.
+     * Apply {@link #effects} to the given {@link GameCharacter}.
      *
      * @param gameCharacter the {@link GameCharacter} to apply {@link BaseEffect}s to.
      */
@@ -54,7 +54,7 @@ public class BaseEffector extends BaseGameEntity implements Effector {
      * Add the given effect to the effector.
      *
      * @param effect to add
-     * @return {@link this}
+     * @return {@code this}
      */
     @Override
     public Effector addEffect(BaseEffect<? extends GameEntity> effect) {

--- a/src/bobbin/effects/Effector.java
+++ b/src/bobbin/effects/Effector.java
@@ -29,7 +29,7 @@ public interface Effector extends GameEntity {
      * Add the given effect to the effector.
      *
      * @param effect to add
-     * @return {@link this}
+     * @return {@code this}
      */
     Effector addEffect(BaseEffect<? extends GameEntity> effect);
 

--- a/src/bobbin/interaction/Interactive.java
+++ b/src/bobbin/interaction/Interactive.java
@@ -16,7 +16,7 @@ public abstract class Interactive {
 
     /**
      * Get the set of actions to present to the player when they {@link #interact(PlayerCharacter,
-     * BaseGameEntity, BufferedReader, PrintWriter)} with {@link this}. Depending on needs, the base
+     * BaseGameEntity, BufferedReader, PrintWriter)} with this object. Depending on needs, the base
      * list should be fetched by subclasses of {@link Interactive}, which should then add to that
      * list.
      *

--- a/src/bobbin/items/Item.java
+++ b/src/bobbin/items/Item.java
@@ -72,7 +72,7 @@ public class Item extends BaseGameEntity {
      *
      * @param items  {@link Item}s to be added to the new {@link Combination}
      * @param result result of the {@link Combination}
-     * @return {@link this}
+     * @return {@code this}
      */
     public Item addCombination(Item result, Item... items) {
         Combination combination = new Combination(items);
@@ -92,7 +92,7 @@ public class Item extends BaseGameEntity {
      *
      * @param combination {@link Combination} to add
      * @param result      result of the {@link Combination}
-     * @return {@link this}
+     * @return {@code this}
      */
     private Item addCombination(Combination combination, Item result) {
         combinations.put(combination, result);

--- a/src/bobbin/main/Main.java
+++ b/src/bobbin/main/Main.java
@@ -58,6 +58,9 @@ public class Main {
     /**
      * Build a room, allowing the player to configure their character.
      *
+     * @param reader player input
+     * @param writer player output
+     *
      * @return {@link PlayerCharacter} in the new game.
      */
     public static PlayerCharacter buildNewGame(BufferedReader reader, PrintWriter writer) {

--- a/test/bobbin/usability/util/BufferedReaderTester.java
+++ b/test/bobbin/usability/util/BufferedReaderTester.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public class BufferedReaderTester extends BufferedReader {
@@ -25,9 +26,8 @@ public class BufferedReaderTester extends BufferedReader {
     }
 
     @Override
-    public String readLine() throws IOException {
-        testActions.getOrDefault(lineNumber, Collections.singletonList(s -> {
-        }))
+    public String readLine() {
+        testActions.getOrDefault(lineNumber, Collections.singletonList(s -> {}))
                    .forEach(stringConsumer -> stringConsumer.accept(baos.toString()));
 
         // Include inputs in the program outputs to make the output look like

--- a/test/bobbin/usability/util/BufferedUserInput.java
+++ b/test/bobbin/usability/util/BufferedUserInput.java
@@ -24,7 +24,7 @@ public class BufferedUserInput {
      * Append a string to the user input.
      *
      * @param s {@link String} to be appended
-     * @return {@link this}
+     * @return {@code this}
      */
     private BufferedUserInput append(String s) {
         inputs.add(inputs.isEmpty() ? s : inputs.removeLast().concat(s));
@@ -35,7 +35,7 @@ public class BufferedUserInput {
      * Append an {@code int} to the user input.
      *
      * @param i {@code int} to be appended
-     * @return {@link this}
+     * @return {@code this}
      */
     private BufferedUserInput append(int i) {
         return append(Integer.toString(i));
@@ -44,7 +44,7 @@ public class BufferedUserInput {
     /**
      * Append a platform-dependent newline character sequence to the user input.
      *
-     * @return {@link this}
+     * @return {@code this}
      */
     public BufferedUserInput newLine() {
         inputs.add("");
@@ -55,7 +55,7 @@ public class BufferedUserInput {
      * Append a string followed by a platform-dependent newline character sequence.
      *
      * @param s {@link String} to be appended
-     * @return {@link this}
+     * @return {@code this}
      */
     public BufferedUserInput appendLine(String s) {
         return append(s).newLine();
@@ -65,17 +65,17 @@ public class BufferedUserInput {
      * Append an {@code int} followed by a platform-dependent newline character sequence.
      *
      * @param i {@code int} to be appended
-     * @return {@link this}
+     * @return {@code this}
      */
     public BufferedUserInput appendLine(int i) {
         return append(i).newLine();
     }
 
     /**
-     * Append a {@link Collection<String>} of user inputs.
+     * Append a {@link Collection} of user inputs.
      *
      * @param list user inputs to append
-     * @return {@link this}
+     * @return {@code this}
      */
     public BufferedUserInput appendAllOnNewLines(Collection<String> list) {
         for (String s : list) {
@@ -88,7 +88,7 @@ public class BufferedUserInput {
      * Append an array of user inputs.
      *
      * @param list user inputs to append
-     * @return {@link this}
+     * @return {@code this}
      */
     public BufferedUserInput appendAllOnNewLines(String... list) {
         return appendAllOnNewLines(Arrays.asList(list));
@@ -108,7 +108,7 @@ public class BufferedUserInput {
      * print all of the output up to that point.
      *
      * @param outputConsumer a consumer for running tests on the output of the program
-     * @return {@link this}
+     * @return {@code this}
      */
     public BufferedUserInput addTestAction(Consumer<String> outputConsumer) {
         int key = inputs.size() - 1;
@@ -118,9 +118,12 @@ public class BufferedUserInput {
     }
 
     /**
-     * Build a {@link BufferedReader} from {@link this}.
+     * Build a {@link BufferedReader} from {@code this}.
      *
-     * @return {@link BufferedReader} whose contents include what has been added to {@link this}
+     * @param baos output stream to write to
+     * @param writer to pass into the test run
+     *
+     * @return {@link BufferedReader} whose contents include what has been added to {@code this}
      */
     public BufferedReader build(ByteArrayOutputStream baos, PrintWriter writer) {
         final String newLine = System.lineSeparator();


### PR DESCRIPTION
- Fix JavaDoc errors
- Add JavaDoc plugin to `pom.xml`, enabling JavaDoc building via Maven
  + See https://maven.apache.org/plugins/maven-javadoc-plugin/usage.html
    for more details on usage
  + `mvn javadoc:javadoc` can be used to generate JavaDocs
  + `mvn javadoc:test-javadoc` can be used to test that JavaDocs are
    properly formed