### PR TITLE
Add Initial Travis CI Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+before_cache:
+  - rm -rf $HOME/.m2/repository/Bobbin
+cache:
+  directories:
+    - $HOME/.m2/repository
+git:
+  quiet: true
+jdk: openjdk11
+language: java
+script: mvn clean test javadoc:test-javadoc jacoco:report -B

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
   <properties>
     <github.global.server>github</github.global.server>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>
@@ -43,8 +44,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
-          <source>1.9</source>
-          <target>1.9</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
 
@@ -60,6 +61,20 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.0.1</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.2</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Closes #31.

Enable Travis CI. For each PR, this will run the following Maven targets:
- `test` to run the unit tests
- `javadoc:test-javadoc` to validate JavaDocs
- `jacoco:report` to generate unit test coverage, which could be useful if Coveralls actually worked

Some other niceties:
- Cache maven dependencies (`~/.m2/repository`) to speed up the build. Takes ~1 minute to run both unit tests and JavaDoc validation with this enabled.